### PR TITLE
Combine remove_batched_job and batch_complete? into a single function so...

### DIFF
--- a/test/test_batched_job.rb
+++ b/test/test_batched_job.rb
@@ -46,7 +46,7 @@ class BatchedJobTest < Test::Unit::TestCase
   # Make sure the after_batch hook is fired
   def test_batch_hook
     assert_equal(false, Job.batch_exist?(@batch_id))
-    
+
     assert_nothing_raised do
       5.times { Resque.enqueue(Job, @batch_id, "arg#{rand(100)}") }
     end
@@ -129,6 +129,11 @@ class BatchedJobTest < Test::Unit::TestCase
   end
 
   def test_remove_batched_job
+    Resque.enqueue(JobWithoutArgs, @batch_id)
+    Resque.enqueue(JobWithoutArgs, @batch_id)
+    assert_equal(1, JobWithoutArgs.remove_batched_job(@batch_id))
+    assert_equal(0, JobWithoutArgs.remove_batched_job(@batch_id))
+
     Resque.enqueue(JobWithoutArgs, @batch_id)
 
     assert_nothing_raised do


### PR DESCRIPTION
... that their operations are both surrounded by the same mutex

In the old code, the if one worker finished the call to remove_batched_job and got interrupted before asking for the mutex in batch_complete?, then another worker could execute remove_batched_job before the first executed batch_complete?, bringing the batch size to zero for BOTH workers. Admittedly a rare case, but might have happened to me once already. I actually had the after_batch hook performed four times.

I haven't added tests for this as I'm not sure how to simulate threads being interrupted, but all of the current tests still pass.
