### PR TITLE
Build fixed, turn is not compatible with minitest 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ group :documentation do
 end
 
 gem 'rake'
+gem 'turn', '~> 0.9.6'
+gem 'minitest', '~> 4.7.5'
+


### PR DESCRIPTION
rake test do not work (along with travis ci builds) because turn is not compatible with minitest 5.
