### PR TITLE
Remove dependence on Resque::Helpers

### DIFF
--- a/lib/resque/batched_job.rb
+++ b/lib/resque/batched_job.rb
@@ -1,2 +1,3 @@
+require 'resque/plugins/batched_job/helpers'
 require 'resque/plugins/batched_job'
 require 'resque/plugins/batched_job/version'

--- a/lib/resque/plugins/batched_job.rb
+++ b/lib/resque/plugins/batched_job.rb
@@ -20,7 +20,7 @@ module Resque
 
     module BatchedJob
 
-      include Resque::Helpers
+      include Helpers
 
       # Helper method used to generate the batch key.
       #

--- a/lib/resque/plugins/batched_job/helpers.rb
+++ b/lib/resque/plugins/batched_job/helpers.rb
@@ -1,0 +1,108 @@
+# This class was pulled from resque/helpers.rb from 1-x-stable
+# to get around an eventual deprecation.
+# These methods may not work in future versions of resque.
+
+require 'multi_json'
+
+# OkJson won't work because it doesn't serialize symbols
+# in the same way yajl and json do.
+if MultiJson.respond_to?(:adapter)
+  raise "Please install the yajl-ruby or json gem" if MultiJson.adapter.to_s == 'MultiJson::Adapters::OkJson'
+elsif MultiJson.respond_to?(:engine)
+  raise "Please install the yajl-ruby or json gem" if MultiJson.engine.to_s == 'MultiJson::Engines::OkJson'
+end
+
+module Resque
+  # Methods used by various classes in Resque.
+  module Plugins
+    module BatchedJob
+      module Helpers
+
+        class DecodeException < StandardError; end
+
+        # Direct access to the Redis instance.
+        def redis
+          # No infinite recursions, please.
+          # Some external libraries depend on Resque::Helpers being mixed into
+          # Resque, but this method causes recursions. If we have a super method,
+          # assume it is canonical. (see #1150)
+          return super if defined?(super)
+
+          Resque.redis
+        end
+
+        # Given a Ruby object, returns a string suitable for storage in a
+        # queue.
+        def encode(object)
+          if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
+            MultiJson.dump object
+          else
+            MultiJson.encode object
+          end
+        end
+
+        # Given a string, returns a Ruby object.
+        def decode(object)
+          return unless object
+
+          begin
+            if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
+              MultiJson.load object
+            else
+              MultiJson.decode object
+            end
+          rescue ::MultiJson::DecodeError => e
+            raise DecodeException, e.message, e.backtrace
+          end
+        end
+
+        # Given a word with dashes, returns a camel cased version of it.
+        #
+        # classify('job-name') # => 'JobName'
+        def classify(dashed_word)
+          dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
+        end
+
+        # Tries to find a constant with the name specified in the argument string:
+        #
+        # constantize("Module") # => Module
+        # constantize("Test::Unit") # => Test::Unit
+        #
+        # The name is assumed to be the one of a top-level constant, no matter
+        # whether it starts with "::" or not. No lexical context is taken into
+        # account:
+        #
+        # C = 'outside'
+        # module M
+        #   C = 'inside'
+        #   C # => 'inside'
+        #   constantize("C") # => 'outside', same as ::C
+        # end
+        #
+        # NameError is raised when the constant is unknown.
+        def constantize(camel_cased_word)
+          camel_cased_word = camel_cased_word.to_s
+
+          if camel_cased_word.include?('-')
+            camel_cased_word = classify(camel_cased_word)
+          end
+
+          names = camel_cased_word.split('::')
+          names.shift if names.empty? || names.first.empty?
+
+          constant = Object
+          names.each do |name|
+            args = Module.method(:const_get).arity != 1 ? [false] : []
+
+            if constant.const_defined?(name, *args)
+              constant = constant.const_get(name)
+            else
+              constant = constant.const_missing(name)
+            end
+          end
+          constant
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/batched_job/helpers.rb
+++ b/lib/resque/plugins/batched_job/helpers.rb
@@ -4,21 +4,10 @@
 
 require 'multi_json'
 
-# OkJson won't work because it doesn't serialize symbols
-# in the same way yajl and json do.
-if MultiJson.respond_to?(:adapter)
-  raise "Please install the yajl-ruby or json gem" if MultiJson.adapter.to_s == 'MultiJson::Adapters::OkJson'
-elsif MultiJson.respond_to?(:engine)
-  raise "Please install the yajl-ruby or json gem" if MultiJson.engine.to_s == 'MultiJson::Engines::OkJson'
-end
-
 module Resque
-  # Methods used by various classes in Resque.
   module Plugins
     module BatchedJob
       module Helpers
-
-        class DecodeException < StandardError; end
 
         # Direct access to the Redis instance.
         def redis
@@ -39,68 +28,6 @@ module Resque
           else
             MultiJson.encode object
           end
-        end
-
-        # Given a string, returns a Ruby object.
-        def decode(object)
-          return unless object
-
-          begin
-            if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-              MultiJson.load object
-            else
-              MultiJson.decode object
-            end
-          rescue ::MultiJson::DecodeError => e
-            raise DecodeException, e.message, e.backtrace
-          end
-        end
-
-        # Given a word with dashes, returns a camel cased version of it.
-        #
-        # classify('job-name') # => 'JobName'
-        def classify(dashed_word)
-          dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
-        end
-
-        # Tries to find a constant with the name specified in the argument string:
-        #
-        # constantize("Module") # => Module
-        # constantize("Test::Unit") # => Test::Unit
-        #
-        # The name is assumed to be the one of a top-level constant, no matter
-        # whether it starts with "::" or not. No lexical context is taken into
-        # account:
-        #
-        # C = 'outside'
-        # module M
-        #   C = 'inside'
-        #   C # => 'inside'
-        #   constantize("C") # => 'outside', same as ::C
-        # end
-        #
-        # NameError is raised when the constant is unknown.
-        def constantize(camel_cased_word)
-          camel_cased_word = camel_cased_word.to_s
-
-          if camel_cased_word.include?('-')
-            camel_cased_word = classify(camel_cased_word)
-          end
-
-          names = camel_cased_word.split('::')
-          names.shift if names.empty? || names.first.empty?
-
-          constant = Object
-          names.each do |name|
-            args = Module.method(:const_get).arity != 1 ? [false] : []
-
-            if constant.const_defined?(name, *args)
-              constant = constant.const_get(name)
-            else
-              constant = constant.const_missing(name)
-            end
-          end
-          constant
         end
       end
     end


### PR DESCRIPTION
`Resque::Helpers` is deprecated and goes away in Resque 2.0.  Using it with latest from `1-x-stable` branch gives you a repeated warnings in the console.

This pulls in the 2 methods that are being used and removes the dependence on the deprecated modules.