### PR TITLE
added small fix to work with latest Resque version

### DIFF
--- a/lib/resque/plugins/batched_job.rb
+++ b/lib/resque/plugins/batched_job.rb
@@ -124,9 +124,7 @@ module Resque
 
         # Handle either Resque 1-x-stable or 2.0.0.pre
         def redis
-          Resque.config.redis
-        rescue NoMethodError => e
-          Resque.redis
+          Resque.respond_to?(:redis) ? Resque.redis : Resque.backend.store
         end
 
         # Lock a batch key before executing Redis commands.  This will ensure

--- a/lib/resque/plugins/batched_job.rb
+++ b/lib/resque/plugins/batched_job.rb
@@ -122,7 +122,10 @@ module Resque
 
       private
 
+        # Handle either Resque 1-x-stable or 2.0.0.pre
         def redis
+          Resque.config.redis
+        rescue NoMethodError => e
           Resque.redis
         end
 


### PR DESCRIPTION
Not sure if this is the best approach, more like a patch, but I tested it with both `1-x-stable` and `2.0.0.pre`. Using `1-x-stable` it just gives some warnings about RbConfig being deprecated which is an [open issue](https://github.com/resque/resque/issues/1236) in that Resque branch.