### PR TITLE
Raise exception when removing fails

### DIFF
--- a/lib/resque/plugins/batched_job.rb
+++ b/lib/resque/plugins/batched_job.rb
@@ -83,7 +83,10 @@ module Resque
       # @param id (see Resque::Plugins::BatchedJob#after_enqueue_batch)
       def remove_batched_job(id, *args)
         mutex(id) do |bid|
-          redis.lrem(bid, 1, Resque.encode(:class => self.name, :args => args))
+          removed_count = redis.lrem(bid, 1, Resque.encode(:class => self.name, :args => args))
+
+          raise "Failed to remove batched job, id: #{id}, args: #{args.join(', ')}" if removed_count != 1
+
           redis.llen(bid)
         end
       end

--- a/test/test_batched_job.rb
+++ b/test/test_batched_job.rb
@@ -152,6 +152,10 @@ class BatchedJobTest < Test::Unit::TestCase
     assert($batch_complete)
     assert(Job.batch_complete?(@batch_id))
     assert_equal(false, Job.batch_exist?(@batch_id))
+
+    assert_raise RuntimeError do
+      Job.remove_batched_job(@batch_id, "foo")
+    end
   end
 
   def test_enqueue_batched_job

--- a/test/test_batched_job.rb
+++ b/test/test_batched_job.rb
@@ -158,6 +158,14 @@ class BatchedJobTest < Test::Unit::TestCase
     end
   end
 
+  def test_mutating_job
+    Resque.enqueue_batched_job(MutatingJob, @batch_id, { 'ok' => 'so far, so good' })
+
+    assert_raise RuntimeError do
+      Resque.reserve(:test).perform
+    end
+  end
+
   def test_enqueue_batched_job
     Resque.enqueue_batched_job(JobWithoutArgs, @batch_id)
     assert(Job.batch_exist?(@batch_id))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,3 +32,17 @@ class JobWithoutArgs
   end
 
 end
+
+class MutatingJob
+  extend Resque::Plugins::BatchedJob
+  @queue = :test
+
+  def self.perform(batch_id, arg)
+    arg['oops'] = 'mutated!!'
+  end
+
+  def self.after_batch_hook(batch_id, arg)
+    $batch_complete = true
+  end
+
+end


### PR DESCRIPTION
#### What's this PR do?

Adds code to raise a RuntimeError if the call to `remove_batched_job` does not actually remove a job from the queue.

Also, adds a test that confirms that mutating the arguments in a `perform` method prevents the job from being removed from the queue when it completes.

I can't say whether this is the right thing to do in this case, but doing nothing certainly seems like the _wrong_ thing to do.

#### What are the relevant tickets?

This doesn't resolve #22, but it does at least clarify one potential cause and provide some useful feedback (an error is raised).